### PR TITLE
Displaying job name with full path

### DIFF
--- a/src/main/resources/com/adq/jenkins/xmljobtodsl/jenkins/JobSelectorView/index.jelly
+++ b/src/main/resources/com/adq/jenkins/xmljobtodsl/jenkins/JobSelectorView/index.jelly
@@ -35,7 +35,7 @@
 										<input type="checkbox" onclick="selectJob(this.checked, ${count})"/>
 									</td>
 									<td align="center" style="vertical-align:middle;">
-										<a href="${app.rootUrl}${project.url}">${j.displayName}</a>
+										<a href="${app.rootUrl}${project.url}">${j.fullName}</a>
 									</td>
 								</tr>
 								<j:set var="count" value="${count+1}"/>


### PR DESCRIPTION
The job selector view may show replicated names in case there are any jobs with the same name but in different folders. This makes it impossible to distinguish which job you are selecting to parse to DSL. I am displaying fullName instead of displayName, so it will look like this: https://github.com/jenkinsci/jenkins/blob/master/core/src/main/resources/hudson/model/Job/index.jelly