### PR TITLE
add support for uno-choice aka ActiveChoices parameters

### DIFF
--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/custom/DSLChoiceTypeStrategy.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/custom/DSLChoiceTypeStrategy.java
@@ -1,0 +1,35 @@
+package com.adq.jenkins.xmljobtodsl.dsl.strategies.custom;
+
+import com.adq.jenkins.xmljobtodsl.parsers.PropertyDescriptor;
+import com.adq.jenkins.xmljobtodsl.dsl.strategies.DSLMethodStrategy;
+import com.adq.jenkins.xmljobtodsl.dsl.strategies.DSLStrategy;
+
+import hudson.model.listeners.ItemListener;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class DSLChoiceTypeStrategy extends DSLMethodStrategy {
+
+    private final String methodName;
+
+    public DSLChoiceTypeStrategy(int tabs, PropertyDescriptor propertyDescriptor, String methodName) {
+        super(tabs, propertyDescriptor, methodName);
+        this.methodName = methodName;
+    }
+
+    @Override
+    public String toDSL() {
+
+        // convert XML choiceType to jobDSL required choiceType
+
+        PropertyDescriptor propertyDescriptor = (PropertyDescriptor) getDescriptor();
+        String choiceType = propertyDescriptor.getValue();
+
+        String fixedChoiceType = printValueAccordingOfItsType(choiceType.substring(choiceType.indexOf("_") + 1));
+
+        return replaceTabs(String.format(getSyntax("syntax.method_call"), methodName, fixedChoiceType), getTabs());
+    }
+
+    private static final Logger LOGGER = Logger.getLogger(DSLChoiceTypeStrategy.class.getName());
+}
+

--- a/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/custom/DSLReferencedParameterStrategy.java
+++ b/src/main/java/com/adq/jenkins/xmljobtodsl/dsl/strategies/custom/DSLReferencedParameterStrategy.java
@@ -1,0 +1,42 @@
+package com.adq.jenkins.xmljobtodsl.dsl.strategies.custom;
+
+import com.adq.jenkins.xmljobtodsl.parsers.PropertyDescriptor;
+import com.adq.jenkins.xmljobtodsl.dsl.strategies.DSLMethodStrategy;
+import com.adq.jenkins.xmljobtodsl.dsl.strategies.DSLStrategy;
+
+import hudson.model.listeners.ItemListener;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class DSLReferencedParameterStrategy extends DSLMethodStrategy {
+
+    private final String methodName;
+
+    public DSLReferencedParameterStrategy(int tabs, PropertyDescriptor propertyDescriptor, String methodName) {
+        super(tabs, propertyDescriptor, methodName);
+        this.methodName = methodName;
+    }
+
+    @Override
+    public String toDSL() {
+
+        // tokenize referenceParameters in to multiple referencedParameter
+
+        StringBuilder dsl = new StringBuilder();
+        PropertyDescriptor propertyDescriptor = (PropertyDescriptor) getDescriptor();
+
+        String referencedParams  = propertyDescriptor.getValue();
+
+        String[] splitParams = referencedParams.split(",");
+
+        for (String param : splitParams) {
+          dsl.append(replaceTabs(String.format(getSyntax("syntax.method_call"), 
+                  methodName, '"' + param.trim() + '"'), getTabs()));
+        }
+
+        return dsl.toString();
+    }
+  
+  private static final Logger LOGGER = Logger.getLogger(DSLReferencedParameterStrategy.class.getName());
+}
+

--- a/src/main/resources/translator.properties
+++ b/src/main/resources/translator.properties
@@ -630,3 +630,79 @@ properties.key.type = PARAMETER
 
 properties.value = value
 properties.value.type = PARAMETER
+
+# Active Choices Parameter
+ 
+org.biouno.unochoice.ChoiceParameter = activeChoiceParam
+org.biouno.unochoice.ChoiceParameter.type = CLOSURE
+ 
+org.biouno.unochoice.ChoiceParameter.name.type = PARAMETER
+ 
+org.biouno.unochoice.ChoiceParameter.description = description
+org.biouno.unochoice.ChoiceParameter.filterable = filterable
+ 
+org.biouno.unochoice.ChoiceParameter.choiceType = choiceType
+org.biouno.unochoice.ChoiceParameter.choiceType.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLChoiceTypeStrategy
+ 
+org.biouno.unochoice.ChoiceParameter.script = groovyScript
+org.biouno.unochoice.ChoiceParameter.script.type = OBJECT
+ 
+org.biouno.unochoice.ChoiceParameter.script.script = script
+org.biouno.unochoice.ChoiceParameter.script.fallbackScript = fallbackScript
+ 
+org.biouno.unochoice.ChoiceParameter.script.secureScript = script
+org.biouno.unochoice.ChoiceParameter.script.secureFallbackScript = fallbackScript
+ 
+
+# Active Choices Reactive Parameter
+
+org.biouno.unochoice.CascadeChoiceParameter = activeChoiceReactiveParam
+org.biouno.unochoice.CascadeChoiceParameter.type = CLOSURE
+ 
+org.biouno.unochoice.CascadeChoiceParameter.name.type = PARAMETER
+ 
+org.biouno.unochoice.CascadeChoiceParameter.description = description
+org.biouno.unochoice.CascadeChoiceParameter.filterable = filterable
+ 
+org.biouno.unochoice.CascadeChoiceParameter.choiceType = choiceType
+org.biouno.unochoice.CascadeChoiceParameter.choiceType.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLChoiceTypeStrategy
+ 
+org.biouno.unochoice.CascadeChoiceParameter.referencedParameters = referencedParameter
+org.biouno.unochoice.CascadeChoiceParameter.referencedParameters.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLReferencedParameterStrategy
+ 
+org.biouno.unochoice.CascadeChoiceParameter.script = groovyScript
+org.biouno.unochoice.CascadeChoiceParameter.script.type = OBJECT
+ 
+org.biouno.unochoice.CascadeChoiceParameter.script.script = script
+org.biouno.unochoice.CascadeChoiceParameter.script.fallbackScript = fallbackScript
+ 
+org.biouno.unochoice.CascadeChoiceParameter.script.secureScript = script
+org.biouno.unochoice.CascadeChoiceParameter.script.secureFallbackScript = fallbackScript
+
+ 
+# Active Choices Reactive Reference Parameter
+
+org.biouno.unochoice.DynamicReferenceParameter = activeChoiceReactiveReferenceParam
+org.biouno.unochoice.DynamicReferenceParameter.type = CLOSURE
+ 
+org.biouno.unochoice.DynamicReferenceParameter.name.type = PARAMETER
+ 
+org.biouno.unochoice.DynamicReferenceParameter.description = description
+org.biouno.unochoice.DynamicReferenceParameter.filterable = filterable
+org.biouno.unochoice.DynamicReferenceParameter.filterLength = filterLength
+org.biouno.unochoice.DynamicReferenceParameter.omitValueField = omitValueField
+ 
+org.biouno.unochoice.DynamicReferenceParameter.choiceType = choiceType
+org.biouno.unochoice.DynamicReferenceParameter.choiceType.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLChoiceTypeStrategy
+ 
+org.biouno.unochoice.DynamicReferenceParameter.referencedParameters = referencedParameter
+org.biouno.unochoice.DynamicReferenceParameter.referencedParameters.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLReferencedParameterStrategy
+ 
+org.biouno.unochoice.DynamicReferenceParameter.script = groovyScript
+org.biouno.unochoice.DynamicReferenceParameter.script.type = OBJECT
+ 
+org.biouno.unochoice.DynamicReferenceParameter.script.script = script
+org.biouno.unochoice.DynamicReferenceParameter.script.fallbackScript = fallbackScript
+ 
+org.biouno.unochoice.DynamicReferenceParameter.script.secureScript = script
+org.biouno.unochoice.DynamicReferenceParameter.script.secureFallbackScript = fallbackScript


### PR DESCRIPTION
I'm not a Java Programmer, but I needed to be able to export some jenkins jobs that use ActiveChoices/uno-choice params, and this plugin did not support them, so I scratched my own itch. I'm not sure if this is the correct way to do this, I suspect it is not, but it's the only way I got it to work. 

I wanted to essentially do the following in the `translator.properties` file:
`org.biouno.unochoice.ChoiceParameter = activeChoiceParam`

`org.biouno.unochoice.ChoiceParameter.type = com.adq.jenkins.xmljobtodsl.dsl.strategies.custom.DSLActiveChoicesStrategy
`

I attempted this, but was not able to, probably due to my lack of familiarity with Java.

Please let me know if there are any issues, and I can fix if necessary.